### PR TITLE
Fixed issue with Match.Error

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -29,7 +29,7 @@ var Match = {
   Integer: ['__integer__'],
 
   Error: function (msg) {
-    throw new Error(msg);
+    this.msg = msg;
   },
 
   test: function (value, pattern) {


### PR DESCRIPTION
new Match.Error never returns a Match.Error object. Instead it returns a new Error object. This makes Match.test to always throw an Error instead of return false.
